### PR TITLE
Add `npm run lint` as pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocascan-frontend",
-  "version": "1.2.1-rc.1",
+  "version": "1.3.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vocascan-frontend",
-      "version": "1.2.1-rc.1",
+      "version": "1.3.0-rc.1",
       "dependencies": {
         "@fontsource/roboto": "^4.5.1",
         "@material-ui/core": "^4.11.2",
@@ -45,6 +45,7 @@
         "eslint": "^7.27.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.4.0",
+        "husky": "^8.0.0",
         "prettier": "^2.5.1",
         "stylelint": "^14.7.1",
         "stylelint-config-recess-order": "^3.0.0",
@@ -10215,6 +10216,21 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -32047,6 +32063,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+    },
+    "husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true
     },
     "hyphenate-style-name": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
     "lint:style": "stylelint \"src/**/*.scss\"",
-    "lint:style:fix": "stylelint --fix \"src/**/*.scss\""
+    "lint:style:fix": "stylelint --fix \"src/**/*.scss\"",
+    "prepare": "husky install"
   },
   "browserslist": {
     "production": [
@@ -75,7 +76,8 @@
     "stylelint": "^14.7.1",
     "stylelint-config-recess-order": "^3.0.0",
     "stylelint-config-sass-guidelines": "^9.0.1",
-    "stylelint-order": "^5.0.0"
+    "stylelint-order": "^5.0.0",
+    "husky": "^8.0.0"
   },
   "metadata": {}
 }


### PR DESCRIPTION
Add `npm run lint` as pre-commit hook

In case you don't want to run the linter, use `git commit --no-verify` or commit through VSCode: https://github.com/microsoft/vscode/issues/105881#issuecomment-700065939

Uses [husky](https://typicode.github.io/husky/#/) to store hooks in version-control