### PR TITLE
Added Styles to override the default autofill style of browsers

### DIFF
--- a/src/Components/Form/TextInput/TextInput.scss
+++ b/src/Components/Form/TextInput/TextInput.scss
@@ -39,7 +39,6 @@
        * If a solid color is required use 'box-shadow'.
       **/
       background-clip: text !important;
-      -webkit-background-clip: text !important;
       -webkit-text-fill-color: $color-main-text;
       caret-color: $color-main-text;
     }

--- a/src/Components/Form/TextInput/TextInput.scss
+++ b/src/Components/Form/TextInput/TextInput.scss
@@ -24,8 +24,6 @@
     background-size: 100% 100%;
     border: unset;
     border-bottom: solid 1px $color-alternative;
-
-    // No transition duration for background and color - Added for autofill styling fix.
     transition: all 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), background 0s, color 0s;
 
     &:focus {
@@ -35,7 +33,6 @@
       box-shadow: none;
     }
     
-    // Overrides the browser autofill styling.
     &:-webkit-autofill {
       /*
        * 'background-clip' to make the background transparent.

--- a/src/Components/Form/TextInput/TextInput.scss
+++ b/src/Components/Form/TextInput/TextInput.scss
@@ -24,7 +24,9 @@
     background-size: 100% 100%;
     border: unset;
     border-bottom: solid 1px $color-alternative;
-    transition: all 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
+
+    // No transition duration for background and color - Added for autofill styling fix.
+    transition: all 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), background 0s, color 0s;
 
     &:focus {
       background-position: 0 0;
@@ -32,7 +34,19 @@
       outline: none;
       box-shadow: none;
     }
-
+    
+    // Overrides the browser autofill styling.
+    &:-webkit-autofill {
+      /*
+       * 'background-clip' to make the background transparent.
+       * If a solid color is required use 'box-shadow'.
+      **/
+      background-clip: text !important;
+      -webkit-background-clip: text !important;
+      -webkit-text-fill-color: $color-main-text;
+      caret-color: $color-main-text;
+    }
+  
     &::placeholder {
       transition: all 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     }


### PR DESCRIPTION
| Status  | Type  |
| :---: | :---: |
| :white_check_mark: Ready | Bug |

## Description

Added background and color styling to override default styling when browser autofill is used

## Motivation and Context

When autofill is used to fill the register / login forms the browser styling is applied to input fields. The default browser styling looks especially bad in dark mode where Webkit browsers apply a white background to the inputs. (Screenshot attached in the issue)

In this PR, the autofill styling has been overridden to appear the same as the default styling of the inputs. This PR fixes #137 issue.

## Screenshots / GIFs (if appropriate):

![vocascan-autofill-fix](https://user-images.githubusercontent.com/59290226/193403916-62b22b23-e87a-4e88-a5cc-2c4f2c1c18c3.gif)
![vocascan-autofill_light](https://user-images.githubusercontent.com/59290226/193403920-57e0a294-0456-4f9d-9801-3250539d7b7b.png)


## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

Fixes #137 
