### PR TITLE
Added ruby character support

### DIFF
--- a/src/Components/VocabCard/VocabCard.jsx
+++ b/src/Components/VocabCard/VocabCard.jsx
@@ -9,6 +9,47 @@ import useLanguage from "../../hooks/useLanguage.js";
 
 import "./VocabCard.scss";
 
+const parseRubyCharacters = (name) => {
+  const regex = /(\[.*?\})/g; // split the string on ruby groups []{}
+  let splitName = name.split(regex);
+
+  if (splitName.length == 1) {
+    return name;
+  }
+
+  let rubiedGroups = [];
+  splitName.forEach((group) => {
+    if (group.startsWith("[")) {
+      const base = group.substring(
+        group.indexOf("[") + 1,
+        group.lastIndexOf("]")
+      );
+
+      const ruby = group.substring(
+        group.indexOf("{") + 1,
+        group.lastIndexOf("}")
+      );
+
+      let rubyTags = (
+        <ruby>
+          {base}
+          <rp>(</rp>
+          <rt>{ruby}</rt>
+          <rp>)</rp>
+        </ruby>
+      );
+
+      rubiedGroups.push(rubyTags);
+    } else {
+      rubiedGroups.push(group);
+    }
+  });
+
+  const rubiedName = <ruby>{rubiedGroups}</ruby>;
+
+  return rubiedName;
+};
+
 const RenderForeignWord = ({ currVocab, isTranslation }) => {
   const foreignWordLanguage = useSelector(
     (state) => state.query.foreignWordLanguage
@@ -21,7 +62,7 @@ const RenderForeignWord = ({ currVocab, isTranslation }) => {
         <p className="description text-wrap">{currVocab.description}</p>
       ) : null}
       <h1 className={`${isTranslation ? "translations" : ""}`}>
-        {currVocab.name}
+        {parseRubyCharacters(currVocab.name)}
       </h1>
       <div className="language-indicator">
         <p>{language?.nativeNames[0]}</p>
@@ -45,7 +86,9 @@ const RenderTranslatedWord = ({ currVocab, isTranslation }) => {
         <p className="my-20 text-wrap">{currVocab.description}</p>
       ) : null}
       <div className={`my-20 ${isTranslation ? "translations" : ""}`}>
-        {currVocab.Translations.map((el) => el.name).join(", ")}
+        {currVocab.Translations.map((el) => parseRubyCharacters(el.name)).join(
+          ", "
+        )}
       </div>
       <div className="language-indicator">
         <p>{language?.nativeNames[0]}</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  |
| :---: | :---: |
| :x: Hold | Feature |

## Description

In asian scripts like Japanese or Chinese there is a concept of [Ruby Characters](https://en.wikipedia.org/wiki/Ruby_character), annotative characters which accompany complex characters. In Japanese these are known as Furigana, and in Chinese as Bopomofo. 

Vocascan could benefit from displaying these characters in the right way. Modern browsers all [support ](https://caniuse.com/ruby) Ruby Characters, and if they don't there is a fallback available.

The Ruby Characters need to be entered in the database in a [standard format](https://japanese.meta.stackexchange.com/questions/806/how-should-i-format-my-questions-on-japanese-language-se/807#807). Use `[]` to enclose the base characters, and `{}` to encase the Ruby characters. This is then parsed to create the appropriate HTML tags.

`[漢字]{かんじ}` will become <ruby>漢字<rt>かんじ</rt></ruby>

## Screenshots / GIFs (if appropriate):
I have made the functionality already for the Vocab Cards. 
![image](https://github.com/vocascan/vocascan-frontend/assets/5796375/37588f20-b6d3-40b1-b1f6-500dea849f60)

Entering the syntax in the edit vocab screen.
![image](https://github.com/vocascan/vocascan-frontend/assets/5796375/8b50eb34-a8d3-4c7a-8929-cf05f058de22)

## Checklist

- [x] I have read the **CONTRIBUTING** document. (This is empty?)
- [ ] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [ ] I have documented my code if needed
- [ ] Move parsing code to utility script (if this exists)
- [ ] Add ruby support to other area's of the app.

## Resolves

resolves #147 
